### PR TITLE
Comparer and collection standardization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,21 @@ This document defines how automated agents (such as Cursor, GitHub Copilot, or o
 - When adding a new interface to a collection, introduce or update the corresponding partial file instead of expanding the base class.
 - Use the existing `RecordDictionary` split as the authoritative reference for how the files should nest and be named.
 
+## Comparers and Interface Implementations
+
+- All equality, comparison, and interface implementations **must directly delegate to the collection’s `Comparer`** (the `IRecordCollectionComparer` instance) and **must not**:
+  - Call other helper methods on the same type,
+  - Contain additional in-class comparison logic,
+  - Or depend on inheritance/overrides to “fix up” behavior.
+- This rule applies to all equality/comparison-related interfaces, including (but not limited to): `IEquatable<T>`, `IComparable<T>`, `IEqualityComparer`, `IEqualityComparer<T>`, `IComparer`, `IComparer<T>`, `IStructuralEquatable`, and `IStructuralComparable`.
+
+## Framework Compatibility (Collections + Extension Methods)
+
+- All collections and extension methods should behave like their base/corelib counterparts for:
+  - **Null handling**: ignore nulls or throw exactly as the framework would for the analogous API.
+  - **Exception behavior**: throw the same exception types the framework throws for the analogous API. Prefer using the BCL-style exceptions (e.g., `ArgumentNullException`, `ArgumentOutOfRangeException`, `InvalidOperationException`) and avoid “custom” exception types for standard argument/state errors.
+  - **Enumerator invalidation**: behaviors such as mutating a list during enumeration must throw `InvalidOperationException` (like `List<T>`), even when a naive array-style implementation would not.
+
 ## Git Committing
 
 - Prefer **small, focused commits** that are easy to understand, review, and diff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,15 @@ Thanks for helping improve Lod.RecordCollections! Keep contributions tightly sco
 - Use `<Type>.cs` for constructors, core state, and invariants, `<Type>.Record.cs` for record contract overrides, and `<Type>.<Interface>.cs` for each interface implementation (for example `RecordSet.IEqualityComparer.cs`).
 - When you add or remove supported interfaces, update the matching partial file instead of expanding the base class. This keeps diffs small and makes it obvious where a given behavior lives.
 - Mirror the existing `RecordDictionary` layout when creating new collection types so that maintainers can navigate and review changes consistently.
+
+## Comparers and Interface Implementations
+
+- All equality, comparison, and interface implementations must **directly call the collection’s `Comparer`** (`IRecordCollectionComparer`) and must not implement additional in-class logic or route through other methods. This ensures predictable behavior when using custom comparers without requiring inheritance.
+- This includes (but isn’t limited to) implementations of: `IEquatable<T>`, `IComparable<T>`, `IEqualityComparer`, `IEqualityComparer<T>`, `IComparer`, `IComparer<T>`, `IStructuralEquatable`, and `IStructuralComparable`.
+
+## Framework Compatibility (Collections + Extension Methods)
+
+- Collections and extension methods should match base/corelib behavior for the analogous API:
+  - **Null handling**: ignore nulls or throw exactly as the framework would.
+  - **Exception behavior**: throw the same exception types as the framework (e.g., `ArgumentNullException`, `ArgumentOutOfRangeException`, `InvalidOperationException`), and avoid introducing custom exception types for standard argument/state violations.
+  - **Enumerator invalidation**: mutating a list during enumeration must throw `InvalidOperationException` (as `List<T>` does), even if a naive array-style implementation would not.


### PR DESCRIPTION
Add guidelines to `AGENTS.md` and `CONTRIBUTING.md` for comparer delegation and framework-compatible collection/extension method behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba122a4d-0b0b-4464-97d8-5b4a7b447673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba122a4d-0b0b-4464-97d8-5b4a7b447673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

