### PR TITLE
chore: renamed repository and updated links and urls

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -45,16 +45,16 @@ jobs:
       run: dotnet test ./src/Lod.RecordCollections.sln -c Release --no-restore --no-build
 
     - name: IL Class/Record Conversion (netstandard2.0))
-      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\lod.recordcollections\lod.recordcollections\src\Lod.RecordCollections\bin\Release\netstandard2.0\Lod.RecordCollections.dll
+      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\dotnet-record-collections\dotnet-record-collections\src\Lod.RecordCollections\bin\Release\netstandard2.0\Lod.RecordCollections.dll
 
     - name: IL Class/Record Conversion (net4.8))
-      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\lod.recordcollections\lod.recordcollections\src\Lod.RecordCollections\bin\Release\net4.8\Lod.RecordCollections.dll
+      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\dotnet-record-collections\dotnet-record-collections\src\Lod.RecordCollections\bin\Release\net4.8\Lod.RecordCollections.dll
 
     - name: IL Class/Record Conversion (net8.0))
-      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\lod.recordcollections\lod.recordcollections\src\Lod.RecordCollections\bin\Release\net8.0\Lod.RecordCollections.dll
+      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\dotnet-record-collections\dotnet-record-collections\src\Lod.RecordCollections\bin\Release\net8.0\Lod.RecordCollections.dll
 
     - name: IL Class/Record Conversion (net10.0))
-      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\lod.recordcollections\lod.recordcollections\src\Lod.RecordCollections\bin\Release\net10.0\Lod.RecordCollections.dll
+      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\dotnet-record-collections\dotnet-record-collections\src\Lod.RecordCollections\bin\Release\net10.0\Lod.RecordCollections.dll
 
     - name: NuGet Pack
       run: dotnet pack ./src/Lod.RecordCollections/Lod.RecordCollections.csproj -c Release --no-restore --include-symbols --no-build -p:Version=${{ steps.set-version.outputs.version }} -p:PackageVersion=${{ steps.set-version.outputs.version }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,13 +29,13 @@ jobs:
       run: dotnet test ./src/Lod.RecordCollections.sln -c Release --no-restore --no-build --verbosity normal
 
     - name: Convert classes to records (netstandard2.0)
-      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\lod.recordcollections\lod.recordcollections\src\Lod.RecordCollections\bin\Release\netstandard2.0\Lod.RecordCollections.dll
+      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\dotnet-record-collections\dotnet-record-collections\src\Lod.RecordCollections\bin\Release\netstandard2.0\Lod.RecordCollections.dll
 
     - name: Convert classes to records (net4.8)
-      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\lod.recordcollections\lod.recordcollections\src\Lod.RecordCollections\bin\Release\net4.8\Lod.RecordCollections.dll
+      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\dotnet-record-collections\dotnet-record-collections\src\Lod.RecordCollections\bin\Release\net4.8\Lod.RecordCollections.dll
 
     - name: Convert classes to records (net8.0)
-      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\lod.recordcollections\lod.recordcollections\src\Lod.RecordCollections\bin\Release\net8.0\Lod.RecordCollections.dll
+      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\dotnet-record-collections\dotnet-record-collections\src\Lod.RecordCollections\bin\Release\net8.0\Lod.RecordCollections.dll
 
     - name: Convert classes to records (net10.0)
-      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\lod.recordcollections\lod.recordcollections\src\Lod.RecordCollections\bin\Release\net10.0\Lod.RecordCollections.dll
+      run: dotnet ./src/Lod.RecordCollections.IlAssembler/bin/Release/net10.0/Lod.RecordCollections.IlAssembler.dll D:\a\dotnet-record-collections\dotnet-record-collections\src\Lod.RecordCollections\bin\Release\net10.0\Lod.RecordCollections.dll

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Record Collections
 
-![Build](https://github.com/lod-softworks/lod.recordcollections/actions/workflows/build-and-test.yml/badge.svg) ![Release](https://img.shields.io/github/v/release/lod-softworks/lod.recordcollections?sort=semver&display_name=release&logo=semanticrelease&label=Release)
+![Build](https://github.com/lod-softworks/dotnet-record-collections/actions/workflows/build-and-test.yml/badge.svg) ![Release](https://img.shields.io/github/v/release/lod-softworks/dotnet-record-collections?sort=semver&display_name=release&logo=semanticrelease&label=Release)
 
 Generic collections that implement value-based equality for use with C# records. Drop-in replacements for standard collections that work correctly with record equality comparison.
 

--- a/src/Lod.RecordCollections/Lod.RecordCollections.csproj
+++ b/src/Lod.RecordCollections/Lod.RecordCollections.csproj
@@ -20,10 +20,10 @@
     <Version>0.1.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>record collection recordcollection recordlist recorddictionary recordset recordarray recordqueue recordstack valuecollection</PackageTags>
-    <PackageProjectUrl>https://github.com/lod-softworks/lod.recordcollections</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/lod-softworks/dotnet-record-collections</PackageProjectUrl>
     <PackageIcon>docs\icon.png</PackageIcon>
     <PackageReadmeFile>docs\README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/lod-softworks/lod.recordcollections</RepositoryUrl>
+    <RepositoryUrl>https://github.com/lod-softworks/dotnet-record-collections</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the repository name from `lod.recordcollections` to `dotnet-record-collections` to better follow GitHub conventions and clarify package purpose.