### PR TITLE
chore: remove default package version number

### DIFF
--- a/src/Lod.RecordCollections/Lod.RecordCollections.csproj
+++ b/src/Lod.RecordCollections/Lod.RecordCollections.csproj
@@ -17,7 +17,6 @@
 
   <PropertyGroup>
     <PackageId>Lod.RecordCollections</PackageId>
-    <Version>0.1.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>record collection recordcollection recordlist recorddictionary recordset recordarray recordqueue recordstack valuecollection</PackageTags>
     <PackageProjectUrl>https://github.com/lod-softworks/dotnet-record-collections</PackageProjectUrl>


### PR DESCRIPTION
Removed version number from project file as this should never have a default and should always be set in the publish step.